### PR TITLE
fix: remove invalid SECURITY_API_TOKEN passthrough breaking reusable workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,5 @@ on:
 jobs:
   golangci_lint_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/golangci-lint.yml@main
-    secrets:
-      SECURITY_API_TOKEN: ${{ secrets.SECURITY_API_TOKEN }}
     with:
       timeout: 20m

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,5 @@ on:
 jobs:
   stale_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/stale.yml@main
-    secrets:
-      SECURITY_API_TOKEN: ${{ secrets.SECURITY_API_TOKEN }}
     with:
       dryRun: ${{ github.event.inputs.dryRun }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,5 +7,3 @@ on:
 jobs:
   sync_labels_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/sync-labels.yml@main
-    secrets:
-      SECURITY_API_TOKEN: ${{ secrets.SECURITY_API_TOKEN }}


### PR DESCRIPTION
## Summary

Every `golangci-lint`, `stale`, and `sync-labels` run has been a `startup_failure` (invalid workflow file) since the Tracebit canary commit added `secrets: SECURITY_API_TOKEN` to calls of the upstream `turbot/steampipe-workflows` reusable workflows. Those reusable workflows don't declare any `secrets` input, so passing a secret is rejected before the job starts — the token was never consumable there. This removes the three invalid `secrets:` blocks to restore valid, runnable workflows.

## Changes

- `.github/workflows/golangci-lint.yml`, `stale.yml`, `sync-labels.yml`: drop the `secrets: SECURITY_API_TOKEN` passthrough to the reusable-workflow calls.

_Integration test logs / example query results: N/A — CI workflow fix only. All three files validated as parseable YAML; the golangci-lint reusable workflow will now actually run._
